### PR TITLE
Update ext Attribute in UserLang to Include Period

### DIFF
--- a/Vue.xml
+++ b/Vue.xml
@@ -1,5 +1,5 @@
 <NotepadPlus>
-    <UserLang name="Vue" ext="vue" udlVersion="2.1">
+    <UserLang name="Vue" ext=".vue" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="no" allowFoldOfComments="no" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="no" Keywords6="no" Keywords7="no" Keywords8="no" />


### PR DESCRIPTION
Notepad++ doesn't actually recognize the file extension defined in the ext attribute of the UserLang tag unless it is preceded by a period.